### PR TITLE
Adding python bindings

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,8 +34,11 @@ jobs:
       - name: smoke test the wheel
         run: |
           python -m venv /tmp/wheelcheck
-          /tmp/wheelcheck/bin/pip install target/wheels/*.whl
-          /tmp/wheelcheck/bin/python python/tests/smoke.py
+          # Windows venvs put executables in Scripts/, unix venvs in bin/.
+          BIN=/tmp/wheelcheck/bin
+          [ -d /tmp/wheelcheck/Scripts ] && BIN=/tmp/wheelcheck/Scripts
+          "$BIN/pip" install target/wheels/*.whl
+          "$BIN/python" python/tests/smoke.py
         shell: bash
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,64 @@
+name: python
+
+on:
+  push:
+    branches: [main]
+    tags: ["py-v*"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: build and smoke (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest # manylinux x86_64
+          - os: ubuntu-24.04-arm # manylinux aarch64
+          - os: macos-latest # arm64
+          - os: macos-13 # x86_64
+          - os: windows-latest # x86_64 msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: build wheel
+        uses: PyO3/maturin-action@v2
+        with:
+          maturin-version: latest
+          args: --release --manifest-path python/Cargo.toml --out target/wheels
+      - name: smoke test the wheel
+        run: |
+          python -m venv /tmp/wheelcheck
+          /tmp/wheelcheck/bin/pip install target/wheels/*.whl
+          /tmp/wheelcheck/bin/python python/tests/smoke.py
+        shell: bash
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: target/wheels
+
+  publish:
+    name: publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/py-v')
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: target/wheels
+          merge-multiple: true
+      - name: publish
+        uses: PyO3/maturin-action@v2
+        with:
+          maturin-version: latest
+          command: publish
+          args: --manifest-path python/Cargo.toml --skip-existing

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,7 +17,6 @@ jobs:
           - os: ubuntu-latest # manylinux x86_64
           - os: ubuntu-24.04-arm # manylinux aarch64
           - os: macos-latest # arm64
-          - os: macos-13 # x86_64
           - os: windows-latest # x86_64 msvc
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@stable
       - name: build wheel
-        uses: PyO3/maturin-action@v2
+        uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           args: --release --manifest-path python/Cargo.toml --out target/wheels
@@ -57,7 +57,7 @@ jobs:
           path: target/wheels
           merge-multiple: true
       - name: publish
-        uses: PyO3/maturin-action@v2
+        uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: publish

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,15 @@
 # Locally generated decay demo frames, kept out of the repo.
 /demo
 
+# Python bindings build artifacts.
+/python/.venv/
+/python/*.so
+/python/*.pyd
+/python/__pycache__/
+/python/tests/__pycache__/
+/dist/
+/target/wheels/
+
 # Documentation lives locally and is never committed.
 CLAUDE.md
 project.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,24 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aligned"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
-dependencies = [
- "as-slice",
-]
-
-[[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,91 +59,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
-
-[[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
-name = "arg_enum_proc_macro"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
-
-[[package]]
-name = "as-slice"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "av-scenechange"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
-dependencies = [
- "aligned",
- "anyhow",
- "arg_enum_proc_macro",
- "arrayvec",
- "log",
- "num-rational",
- "num-traits",
- "pastey",
- "rayon",
- "thiserror",
- "v_frame",
- "y4m",
-]
-
-[[package]]
-name = "av1-grain"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
-dependencies = [
- "anyhow",
- "arrayvec",
- "log",
- "nom",
- "num-rational",
- "v_frame",
-]
-
-[[package]]
-name = "avif-serialize"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
-dependencies = [
- "arrayvec",
-]
 
 [[package]]
 name = "bit_field"
@@ -176,27 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
-name = "bitstream-io"
-version = "4.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
-dependencies = [
- "no_std_io2",
-]
-
-[[package]]
-name = "built"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
-
-[[package]]
-name = "bumpalo"
-version = "3.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,18 +87,6 @@ name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
-
-[[package]]
-name = "cc"
-version = "1.2.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
-dependencies = [
- "find-msvc-tools",
- "jobserver",
- "libc",
- "shlex",
-]
 
 [[package]]
 name = "cfg-if"
@@ -324,7 +192,16 @@ version = "0.1.1"
 dependencies = [
  "clap",
  "image",
- "rand 0.8.6",
+ "rand",
+ "rayon",
+]
+
+[[package]]
+name = "decayfmt-py"
+version = "0.1.0"
+dependencies = [
+ "decayfmt",
+ "pyo3",
 ]
 
 [[package]]
@@ -332,26 +209,6 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "exr"
@@ -363,7 +220,6 @@ dependencies = [
  "half",
  "lebe",
  "miniz_oxide",
- "rayon-core",
  "smallvec",
  "zune-inflate",
 ]
@@ -384,12 +240,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,18 +258,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
 ]
 
 [[package]]
@@ -465,9 +303,6 @@ dependencies = [
  "num-traits",
  "png",
  "qoi",
- "ravif",
- "rayon",
- "rgb",
  "tiff",
  "zune-core",
  "zune-jpeg",
@@ -484,46 +319,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "imgref"
-version = "1.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
-
-[[package]]
-name = "interpolate_name"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
 
 [[package]]
 name = "lebe"
@@ -536,47 +335,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libfuzzer-sys"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
-dependencies = [
- "arbitrary",
- "cc",
-]
-
-[[package]]
-name = "log"
-version = "0.4.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "loop9"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
-dependencies = [
- "imgref",
-]
-
-[[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
- "rayon",
-]
-
-[[package]]
-name = "memchr"
-version = "2.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miniz_oxide"
@@ -596,77 +354,6 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
-]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "no_std_io2"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -691,18 +378,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
-
-[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +389,12 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "ppv-lite86"
@@ -734,29 +415,67 @@ dependencies = [
 ]
 
 [[package]]
-name = "profiling"
-version = "1.0.18"
+name = "pxfm"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "pyo3"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
- "profiling-procmacros",
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
 ]
 
 [[package]]
-name = "profiling-procmacros"
-version = "1.0.18"
+name = "pyo3-build-config"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
  "quote",
  "syn",
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.29"
+name = "pyo3-macros-backend"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "qoi"
@@ -783,30 +502,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -816,17 +519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -835,66 +528,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rav1e"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
-dependencies = [
- "aligned-vec",
- "arbitrary",
- "arg_enum_proc_macro",
- "arrayvec",
- "av-scenechange",
- "av1-grain",
- "bitstream-io",
- "built",
- "cfg-if",
- "interpolate_name",
- "itertools",
- "libc",
- "libfuzzer-sys",
- "log",
- "maybe-rayon",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "paste",
- "profiling",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "simd_helpers",
- "thiserror",
- "v_frame",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "ravif"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
-dependencies = [
- "avif-serialize",
- "imgref",
- "loop9",
- "quick-error",
- "rav1e",
- "rayon",
- "rgb",
+ "getrandom",
 ]
 
 [[package]]
@@ -918,49 +552,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "rgb"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "shlex"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simd_helpers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
-dependencies = [
- "quote",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -980,24 +581,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.18"
+name = "target-lexicon"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tiff"
@@ -1026,75 +613,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "v_frame"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
-dependencies = [
- "aligned-vec",
- "num-traits",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
-dependencies = [
- "unicode-ident",
-]
 
 [[package]]
 name = "weezl"
@@ -1116,18 +638,6 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "y4m"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,25 @@ exclude = ["assets/", ".github/"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-image = "0.25"
+image = { version = "0.25", default-features = false, features = [
+    "bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "png", "pnm",
+    "qoi", "tga", "tiff", "webp",
+] }
 rand = "0.8"
+rayon = "1"
 
 [profile.release]
 strip = true
+
+[[bench]]
+name = "corrupt"
+harness = false
+
+[[bench]]
+name = "encode"
+harness = false
+
+[workspace]
+members = ["python"]
+default-members = ["."]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/aravpanwar/decayfmt/actions/workflows/ci.yml/badge.svg)](https://github.com/aravpanwar/decayfmt/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/decayfmt.svg)](https://crates.io/crates/decayfmt)
+[![PyPI](https://img.shields.io/pypi/v/decayfmt-py.svg)](https://pypi.org/project/decayfmt-py/)
 
 _Featured in [This Week in Rust #660](https://this-week-in-rust.org/blog/2026/07/15/this-week-in-rust-660/)._
 
@@ -175,6 +176,61 @@ decayfmt open note.tdcy7
 ```
 
 `x` is read from the filename, so renaming the file changes how hard the next open hits.
+
+## Python
+
+The same library is available from Python as the `decayfmt` package — same format,
+same statistics, same errors as the CLI:
+
+```
+pip install decayfmt-py
+```
+
+```python
+import decayfmt
+
+decayfmt.encode_file("notes.txt", "notes.tdcy5")
+
+# Each open permanently corrupts the file on disk.
+for _ in range(5):
+    kind, dims, data = decayfmt.decay_file("notes.tdcy5")
+    print(data[16:].decode("utf-8", errors="replace"))
+
+# Or decay bytes in memory, no files involved:
+data = b"the quick brown fox jumps over the lazy dog"
+for _ in range(8):
+    data = decayfmt.corrupt_bytes(data, 1.0, "text")
+```
+
+The binding exposes `corrupt_bytes` (copy out), `corrupt_in_place` (zero-copy on a
+`bytearray`), `encode_file`, `encode_bytes`, `decay_file` (open without display),
+`parse_filename`, `read_header`, and `write_header`. The GIL is released while
+corruption runs, and large payloads are corrupted in parallel across cores. Full
+documentation is on [PyPI](https://pypi.org/project/decayfmt-py/) and in
+[`python/README.md`](python/README.md).
+
+## Performance
+
+Corruption was rewritten around bulk random draws and a parallel region split
+(each region seeds its own OS-entropy generator), and encoding no longer builds a
+second full-size buffer. Measured on an Apple silicon Mac (10 logical cores),
+64 MiB payload, release build, `cargo bench --bench corrupt` / `--bench encode`:
+
+| Scenario | Before | After | Speedup |
+| :--- | ---: | ---: | ---: |
+| text corruption, x=1 | 142 MiB/s | 1,366 MiB/s | 9.6x |
+| text corruption, x=10 | 86 MiB/s | 754 MiB/s | 8.8x |
+| image corruption, x=1 | 187 MiB/s | 1,421 MiB/s | 7.6x |
+| image corruption, x=10 | 116 MiB/s | 950 MiB/s | 8.2x |
+| encode 16 MiB image | 33.2 ms | 32.3 ms | ~1x |
+| encode 16 MiB text | 7.9 ms | 3.9 ms | 2.0x |
+
+The corruption loop itself is now bounded by entropy generation and memory
+bandwidth rather than per-byte RNG calls. End-to-end encode is dominated by image
+decoding and disk I/O, which the rewrite does not touch, so those numbers move
+little. The same distribution holds: per-byte probabilities are quantized to
+1/65536 granularity, about 1.5e-5 absolute error, far below anything a filename
+`x` can distinguish, and the statistical test suite verifies it.
 
 ## How the corruption works
 

--- a/benches/corrupt.rs
+++ b/benches/corrupt.rs
@@ -1,0 +1,91 @@
+//! Manual timing benchmark for the corruption loop.
+//!
+//! Runs `corrupt::corrupt` over a deterministic pattern-filled payload for the
+//! four scenarios {text, image} x {x = 1, x = 10}, adapting the repetition count
+//! until each scenario has run for at least ~1.5 s, then reports MiB/s. The
+//! payload fill uses a cheap xorshift generator so the timing measures the
+//! corruption pass itself, not entropy seeding or allocation.
+//!
+//! Usage: `cargo bench --bench corrupt` (release profile by default).
+//! Payload size defaults to 64 MiB; override with `DECAY_BENCH_MB=256 cargo bench --bench corrupt`.
+
+use decayfmt::corrupt::corrupt;
+use decayfmt::format::FileType;
+use std::time::Instant;
+
+const DEFAULT_PAYLOAD_MB: usize = 64;
+const MIN_SCENARIO_SECS: f64 = 1.5;
+
+/// Fills `bytes` with a cheap deterministic pattern (xorshift64). Deterministic
+/// so runs are comparable; not cryptographically strong, which is fine because
+/// it never feeds the corruption RNG — `corrupt` seeds its own from OS entropy.
+fn fill_pattern(bytes: &mut [u8]) {
+    let mut state = 0x243F_6A88_85A3_08D3u64;
+    for chunk in bytes.chunks_mut(8) {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let words = state.to_le_bytes();
+        let n = chunk.len();
+        chunk.copy_from_slice(&words[..n]);
+    }
+}
+
+/// Times one scenario, adapting the repetition count until `MIN_SCENARIO_SECS`
+/// has elapsed, and prints throughput.
+fn bench_scenario(payload: &mut [u8], file_type: FileType, x: f64, payload_mb: f64) {
+    // Warmup: one untimed pass so caches and code paths are hot.
+    corrupt(payload, file_type, x);
+
+    let mut reps = 1u64;
+    let (elapsed, count) = loop {
+        let start = Instant::now();
+        for _ in 0..reps {
+            corrupt(payload, file_type, x);
+        }
+        let elapsed = start.elapsed();
+        if elapsed.as_secs_f64() >= MIN_SCENARIO_SECS {
+            break (elapsed, reps);
+        }
+        reps *= 2;
+    };
+
+    let gib_per_sec = payload_mb * count as f64 / elapsed.as_secs_f64() / 1024.0;
+    let mib_per_sec = payload_mb * count as f64 / elapsed.as_secs_f64();
+    println!(
+        "{:>5} x={:<3}: {:>8.1} MiB/s  ({:>6} reps in {:>6.2} s, payload {:.0} MiB)",
+        file_type.label(),
+        x,
+        mib_per_sec,
+        count,
+        elapsed.as_secs_f64(),
+        payload_mb,
+    );
+    println!("        x={:<3}: {:>8.3} GiB/s", x, gib_per_sec);
+}
+
+fn main() {
+    let payload_mb = std::env::var("DECAY_BENCH_MB")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_PAYLOAD_MB);
+    let payload_len = payload_mb * 1024 * 1024;
+    let payload_mb_f = payload_mb as f64;
+
+    let mut payload = vec![0u8; payload_len];
+    fill_pattern(&mut payload);
+    println!(
+        "corruption loop benchmark — payload {} MiB ({} bytes), scenarios until >= {:.1} s each",
+        payload_mb, payload_len, MIN_SCENARIO_SECS
+    );
+    println!("cores reported by rayon: {}", rayon::current_num_threads());
+
+    for (file_type, x) in [
+        (FileType::Text, 1.0),
+        (FileType::Text, 10.0),
+        (FileType::Image, 1.0),
+        (FileType::Image, 10.0),
+    ] {
+        bench_scenario(&mut payload, file_type, x, payload_mb_f);
+    }
+}

--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -1,0 +1,88 @@
+//! Manual timing benchmark for end-to-end encode.
+//!
+//! Builds one 2048x2048 RGBA image (16 MiB raw payload) and one 16 MiB text
+//! source, saves each once outside the timed region, then times
+//! `encode::encode_file` repeatedly on the same pair of paths. Reports
+//! wall-time per encode; the numbers bound what any client (CLI or Python)
+//! can achieve end to end, since PNG decode and disk I/O dominate.
+//!
+//! Usage: `cargo bench --bench encode` (release profile by default).
+
+use decayfmt::encode::encode_file;
+use std::path::{Path, PathBuf};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+const MIN_SCENARIO_SECS: f64 = 1.5;
+const IMAGE_SIDE: u32 = 2048;
+const TEXT_MB: usize = 16;
+
+/// Unique path in the system temp directory so concurrent runs do not collide.
+fn unique_temp_path(suffix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("decayfmt_bench_{}_{}", nanos, suffix))
+}
+
+fn bench(name: &str, input: &Path, output: &Path, payload_bytes: usize) {
+    // Warmup: one untimed encode so caches and code paths are hot.
+    encode_file(input, output).expect("warmup encode");
+
+    let mut reps = 1u64;
+    let (elapsed, count) = loop {
+        let start = Instant::now();
+        for _ in 0..reps {
+            encode_file(input, output).expect("timed encode");
+        }
+        let elapsed = start.elapsed();
+        if elapsed.as_secs_f64() >= MIN_SCENARIO_SECS {
+            break (elapsed, reps);
+        }
+        reps *= 2;
+    };
+
+    let per_rep = elapsed.as_secs_f64() / count as f64;
+    println!(
+        "{:>5} encode: {:>8.1} ms/encode  ({:>6} reps in {:>6.2} s, {:.1} MiB source payload)",
+        name,
+        per_rep * 1000.0,
+        count,
+        elapsed.as_secs_f64(),
+        payload_bytes as f64 / (1024.0 * 1024.0),
+    );
+}
+
+fn main() {
+    let image_input = unique_temp_path("source.png");
+    let image_output = unique_temp_path("photo.idcy3");
+    let text_input = unique_temp_path("source.txt");
+    let text_output = unique_temp_path("note.tdcy3");
+
+    // 2048x2048 RGBA = 16 MiB raw payload. Save the PNG once, outside timing.
+    let image = image::RgbaImage::from_fn(IMAGE_SIDE, IMAGE_SIDE, |x, y| {
+        image::Rgba([
+            (x as u8).wrapping_mul(3),
+            (y as u8).wrapping_mul(5),
+            ((x ^ y) as u8).wrapping_mul(7),
+            255,
+        ])
+    });
+    image.save(&image_input).expect("save bench source png");
+    let image_raw_bytes = (IMAGE_SIDE as usize) * (IMAGE_SIDE as usize) * 4;
+
+    // 16 MiB of printable ASCII, no entropy cost, valid UTF-8.
+    let text: Vec<u8> = (0..TEXT_MB * 1024 * 1024)
+        .map(|i| b'a' + (i % 26) as u8)
+        .collect();
+    std::fs::write(&text_input, &text).expect("write bench source text");
+
+    println!("encode benchmark — end to end (read + decode + build + write)");
+    bench("image", &image_input, &image_output, image_raw_bytes);
+    bench("text", &text_input, &text_output, text.len());
+
+    let _ = std::fs::remove_file(&image_input);
+    let _ = std::fs::remove_file(&image_output);
+    let _ = std::fs::remove_file(&text_input);
+    let _ = std::fs::remove_file(&text_output);
+}

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "decayfmt-py"
+version = "0.1.0"
+edition = "2021"
+description = "Python bindings for decayfmt, the file format where decay is a first-class property."
+license = "MIT"
+publish = false
+
+[lib]
+name = "decayfmt_py"
+crate-type = ["cdylib"]
+
+[dependencies]
+decayfmt-core = { path = "..", package = "decayfmt" }
+pyo3 = { version = "0.29", features = ["abi3-py311"] }

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,78 @@
+# decayfmt-py
+
+A file format where decay is a first-class property: **every open permanently corrupts the file.**
+
+This is the Python binding for the [decayfmt](https://github.com/aravpanwar/decayfmt) format. Install it with `pip install decayfmt-py`; the module you import is `decayfmt`. Encode a clean file once, then let it decay one open at a time. Each open replaces a random slice of the payload with noise and writes the damage back to disk — irreversibly. There is no undo, no cache, and no way to view the file without paying for it. The header is immutable; only the payload decays.
+
+The binding wraps the same Rust library the CLI uses, so behavior, statistics, and errors are identical.
+
+## Install
+
+```bash
+pip install decayfmt-py
+```
+
+Requires Python 3.11+. Wheels are built from Rust via PyO3 (abi3), so no Rust toolchain is needed at install time.
+
+## Quickstart
+
+```python
+import decayfmt
+
+# Encode a clean text file. The extension carries the type and the decay rate:
+# `tdcy<x>` = text, `idcy<x>` = image, x = instability (higher decays faster).
+decayfmt.encode_file("notes.txt", "notes.tdcy5")
+
+# Open it five times. Each open permanently corrupts the file on disk.
+for _ in range(5):
+    kind, dims, data = decayfmt.decay_file("notes.tdcy5")
+    print(data[16:].decode("utf-8", errors="replace"))
+
+# Work purely in memory instead: each call decays a fresh copy of the bytes.
+data = b"the quick brown fox jumps over the lazy dog"
+for _ in range(8):
+    data = decayfmt.corrupt_bytes(data, 1.0, "text")
+print(data.decode("utf-8", errors="replace"))
+
+# Zero-copy decay of a mutable buffer:
+buf = bytearray(b"some text that will decay")
+decayfmt.corrupt_in_place(buf, 10.0, "text")
+```
+
+Corruption probability per eligible byte is `p = 1 - exp(-x / 10)`: x = 1 corrupts roughly 9.5% per open, x = 10 roughly 63%. Image corruption touches only the R, G, and B channels — transparency (alpha) is never damaged. Text corruption replaces bytes with printable ASCII and may break UTF-8 sequences, which is the point.
+
+## API
+
+| Function | Returns | Notes |
+| --- | --- | --- |
+| `corrupt_bytes(data, x, kind) -> bytes` | corrupted copy | `kind` is `"image"` or `"text"`; immutable bytes are copied once |
+| `corrupt_in_place(buffer, x, kind) -> None` | — | mutates a `bytearray` in place, no copy; for a `memoryview` use `bytearray(mv)` |
+| `encode_file(source_path, output_path) -> None` | — | same as the CLI `encode`; output name decides type and x |
+| `encode_bytes(source, output_path) -> None` | — | encodes in-memory bytes (image formats decoded, text validated as UTF-8) |
+| `decay_file(path) -> (kind, dims, bytes)` | type label, `(w, h)` or `None`, full file bytes | **permanently corrupts the file on disk**, no display |
+| `parse_filename(name) -> (kind, x)` | — | `"photo.idcy3"` → `("image", 3.0)` |
+| `read_header(data) -> (kind, dims)` | — | reads the 16-byte header |
+| `write_header(kind, width, height) -> bytes` | 16-byte header | image requires `width` and `height` |
+| `decayfmt.__version__` | version string | — |
+
+`x` is not clamped: `x <= 0` corrupts nothing, and large `x` approaches corrupting every byte. The CLI reads x from filenames as a positive integer; the API accepts any float.
+
+## Errors
+
+Failures raise built-in exceptions with the exact message the CLI would print:
+
+- `OSError` — filesystem read/write failures (includes the OS error string).
+- `PermissionError` — the target file is read-only; opening must cost a corruption, so it is refused.
+- `ValueError` — everything else: wrong magic bytes, unknown version, bad filename convention, invalid UTF-8 at encode, undecodable image, and so on.
+
+## Threading
+
+The GIL is released while corruption, encoding, and file operations run, and large payloads (≥ 1 MiB) are corrupted in parallel across cores. Corruption is always drawn from OS-entropy-seeded generators — never deterministic, never replayable.
+
+## Image formats
+
+`encode_file` / `encode_bytes` accept whatever the underlying Rust image library decodes: PNG, JPEG, GIF, WebP, TIFF, QOI, BMP, DDS, EXR, HDR, ICO, PNM, TGA, and farbfeld. Images are stored as raw RGBA, so any format you can decode becomes a decaying image.
+
+## License
+
+MIT. Same license as the [decayfmt](https://github.com/aravpanwar/decayfmt) project.

--- a/python/RELEASE.md
+++ b/python/RELEASE.md
@@ -1,0 +1,48 @@
+# Releasing the Python package
+
+The wheel build + publish is fully automated; a release is a version bump and a tag.
+
+## One-time setup (PyPI)
+
+1. Create the PyPI project once (name `decayfmt-py`) on <https://pypi.org>.
+2. Add a trusted publisher for the repo: PyPI → project → Publishing →
+   "Add a new pending publisher", with:
+   - Owner: `aravpanwar`, Repository: `decayfmt`
+   - Workflow name: `python.yml`
+   - Environment name: `pypi`
+3. Create a GitHub environment named `pypi` (repo → Settings → Environments)
+   so the publish job's `environment: pypi` gate is satisfied. No secrets are
+   needed — publishing uses OpenID Connect.
+
+## Releasing a new version
+
+1. Bump `version` in **both** `python/Cargo.toml` and `python/pyproject.toml`
+   in one commit. The two must match; `smoke.py` asserts the Cargo one.
+2. Tag and push:
+
+   ```bash
+   git tag py-v0.1.0
+   git push origin py-v0.1.0
+   ```
+
+3. The `python` workflow builds and smoke-tests wheels on five platforms
+   (manylinux x86_64 + aarch64, macOS arm64 + x86_64, Windows msvc), then the
+   `publish` job uploads them to PyPI.
+
+   PyPI tags are deliberately separate from CLI release tags (`v*`), so
+   Python versions and CLI versions can ship independently.
+
+4. Verify:
+
+   ```bash
+   python -m venv /tmp/decayfmt-check && /tmp/decayfmt-check/bin/pip install -U decayfmt-py
+   /tmp/decayfmt-check/bin/python python/tests/smoke.py
+   ```
+
+## Local build (optional)
+
+```bash
+python3 -m venv python/.venv && python/.venv/bin/pip install -U pip maturin
+python/.venv/bin/maturin develop --manifest-path python/Cargo.toml
+python/.venv/bin/maturin build --release --manifest-path python/Cargo.toml
+```

--- a/python/examples/example.py
+++ b/python/examples/example.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Example: every decayfmt Python function, plus its exceptions.
+
+Install first:
+
+    pip install decayfmt-py
+
+Then run this file from anywhere. It creates its files in a temporary
+directory and cleans them up, so it is safe to run repeatedly.
+
+Each section below shows one function. The exception section shows every
+error type the bindings can raise and how to catch them.
+"""
+
+import base64
+import shutil
+import tempfile
+from pathlib import Path
+
+import decayfmt
+
+print(f"decayfmt {decayfmt.__version__} loaded")
+print()
+
+tmp = Path(tempfile.mkdtemp(prefix="decayfmt_example_"))
+
+# ---------------------------------------------------------------------------
+# parse_filename: read type + instability x from a decayfmt name
+# ---------------------------------------------------------------------------
+kind, x = decayfmt.parse_filename("photo.idcy3")
+print(f"parse_filename('photo.idcy3') -> kind={kind!r}, x={x}")
+kind, x = decayfmt.parse_filename("note.tdcy12")
+print(f"parse_filename('note.tdcy12') -> kind={kind!r}, x={x}")
+print()
+
+# ---------------------------------------------------------------------------
+# corrupt_bytes: decay a copy of immutable bytes, returns new bytes
+# ---------------------------------------------------------------------------
+data = b"the quick brown fox jumps over the lazy dog"
+original = data
+for step in range(8):
+    data = decayfmt.corrupt_bytes(data, 1.0, "text")
+print("corrupt_bytes: 8 opens of the same bytes in memory")
+print("  before:", original)
+print("  after: ", data)
+print()
+
+# ---------------------------------------------------------------------------
+# corrupt_in_place: same statistics, but mutates a bytearray with no copy
+# ---------------------------------------------------------------------------
+buf = bytearray(b"some text that will decay in place")
+decayfmt.corrupt_in_place(buf, 10.0, "text")
+print("corrupt_in_place: mutated in place, no copy")
+print("  after: ", bytes(buf))
+print()
+
+# image corruption never touches the alpha channel (every 4th byte):
+pixels = bytearray(b"\x00\x00\x00\xFF" * 100)
+decayfmt.corrupt_in_place(pixels, 10.0, "image")
+alphas = pixels[3::4]
+assert all(a == 0xFF for a in alphas), "alpha must survive"
+print("corrupt_in_place: image alpha channel preserved")
+print()
+
+# ---------------------------------------------------------------------------
+# encode_file: source file on disk -> clean decayfmt file on disk
+# ---------------------------------------------------------------------------
+source = tmp / "notes.txt"
+source.write_text("hello from the example file\n")
+output = tmp / "notes.tdcy5"
+
+decayfmt.encode_file(str(source), str(output))
+print(f"encode_file: wrote clean decayfmt file to {output.name}")
+print()
+
+# ---------------------------------------------------------------------------
+# decay_file: open without display — PERMANENTLY corrupts the file on disk
+# ---------------------------------------------------------------------------
+kind, dims, file_bytes = decayfmt.decay_file(str(output))
+print(f"decay_file: kind={kind!r}, dims={dims}, first 16 bytes = header")
+print("  corrupted text:", file_bytes[16:].decode("utf-8", errors="replace"))
+
+kind, dims, file_bytes = decayfmt.decay_file(str(output))
+print("  one more open:", file_bytes[16:].decode("utf-8", errors="replace"))
+print()
+
+# ---------------------------------------------------------------------------
+# encode_bytes: encode bytes already in memory (no source file needed)
+# ---------------------------------------------------------------------------
+png = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+photo_out = tmp / "photo.idcy3"
+decayfmt.encode_bytes(png, str(photo_out))
+kind, dims, _ = decayfmt.decay_file(str(photo_out))
+print(f"encode_bytes: 1x1 PNG from memory -> kind={kind!r}, dims={dims}")
+print()
+
+# ---------------------------------------------------------------------------
+# write_header / read_header: build and inspect the 16-byte header
+# ---------------------------------------------------------------------------
+header = decayfmt.write_header("image", 64, 48)
+print("write_header: 16 bytes:", header.hex())
+kind, dims = decayfmt.read_header(header)
+print(f"read_header:   kind={kind!r}, dims={dims}")
+
+text_header = decayfmt.write_header("text", None, None)
+print(f"read_header:   {decayfmt.read_header(text_header)}")
+print()
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+print("Exceptions:")
+
+
+def show_exception(label, fn):
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - demonstrating all error types
+        print(f"  {label:<38} -> {type(e).__name__}: {e}")
+    else:
+        raise AssertionError(f"{label} did not raise!")
+
+
+# ValueError: kind must be "image" or "text"
+show_exception("corrupt_bytes(bad kind)", lambda: decayfmt.corrupt_bytes(b"x", 1.0, "video"))
+
+# ValueError: filename does not fit the convention
+show_exception("parse_filename('plain.txt')", lambda: decayfmt.parse_filename("plain.txt"))
+show_exception("parse_filename('photo.idcy')", lambda: decayfmt.parse_filename("photo.idcy"))
+show_exception("parse_filename('photo.idcy0')", lambda: decayfmt.parse_filename("photo.idcy0"))
+
+# ValueError: image header requires dimensions
+show_exception("write_header('image', None, None)", lambda: decayfmt.write_header("image", None, None))
+
+# ValueError: text must be valid UTF-8 at encode time
+bad_text = tmp / "bad.tdcy3"
+show_exception(
+    "encode_bytes(invalid UTF-8)",
+    lambda: decayfmt.encode_bytes(b"\xff\xfe not utf8", str(bad_text)),
+)
+
+# ValueError: source cannot be decoded as an image
+bad_png = tmp / "fake.idcy3"
+show_exception(
+    "encode_bytes(not an image)",
+    lambda: decayfmt.encode_bytes(b"definitely not a png", str(bad_png)),
+)
+
+# ValueError: wrong magic bytes — the name fits, the contents are not a decayfmt file
+not_decayfmt = tmp / "fake.tdcy3"
+not_decayfmt.write_text("just a text file")
+show_exception("decay_file(wrong magic)", lambda: decayfmt.decay_file(str(not_decayfmt)))
+
+# ValueError: extension/header type mismatch (image file under a text name)
+mismatched = tmp / "photo.tdcy3"
+decayfmt.encode_bytes(png, str(photo_out))
+Path(str(photo_out)).rename(mismatched)
+show_exception("decay_file(type mismatch)", lambda: decayfmt.decay_file(str(mismatched)))
+
+# OSError: filesystem failure — source does not exist
+show_exception(
+    "encode_file(missing source)",
+    lambda: decayfmt.encode_file(str(tmp / "nope.txt"), str(tmp / "out.tdcy3")),
+)
+
+# PermissionError: read-only target is refused (opening must cost a corruption)
+readonly = tmp / "locked.tdcy3"
+decayfmt.encode_file(str(source), str(readonly))
+readonly.chmod(0o444)
+show_exception("decay_file(read-only target)", lambda: decayfmt.decay_file(str(readonly)))
+readonly.chmod(0o644)
+print()
+
+print("All functions and exceptions demonstrated. Cleaning up.")
+shutil.rmtree(tmp)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "decayfmt-py"
+version = "0.1.0"
+description = "A file format where decay is a first-class property. Every open permanently corrupts the file. Python bindings for the decayfmt CLI format."
+readme = "README.md"
+requires-python = ">=3.11"
+license = "MIT"
+authors = [{ name = "Arav Panwar" }]
+keywords = ["corruption", "decay", "file-format", "entropy"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Rust",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/aravpanwar/decayfmt"
+
+[tool.maturin]
+module-name = "decayfmt"
+manifest-path = "Cargo.toml"
+features = []

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ description = "A file format where decay is a first-class property. Every open p
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
-authors = [{ name = "Arav Panwar" }]
+authors = [{ name = "Arav Panwar" }, { name = "AAVision" }]
 keywords = ["corruption", "decay", "file-format", "entropy"]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,0 +1,196 @@
+//! Python bindings for decayfmt, the file format where decay is a first-class
+//! property: every open permanently corrupts the file.
+//!
+//! This module wraps the Rust library crate directly — the same corruption,
+//! encode, and header routines the CLI uses — and exposes them as plain
+//! functions. Errors map to built-in Python exceptions: filesystem failures
+//! raise `OSError`, a read-only target raises `PermissionError`, and every
+//! other refusal (bad magic, bad filename, invalid UTF-8, ...) raises
+//! `ValueError`, each carrying the exact message the CLI would print.
+
+use decayfmt_core::error::DecayError;
+use decayfmt_core::format::{FileType, Header};
+use pyo3::exceptions::{PyOSError, PyPermissionError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyByteArray, PyByteArrayMethods, PyBytes, PyBytesMethods};
+use std::path::Path;
+
+/// Maps a `DecayError` to the built-in Python exception that best matches it.
+///
+/// `Io` becomes `OSError` (the message already includes the OS error string),
+/// `ReadOnly` becomes `PermissionError`, and everything else becomes
+/// `ValueError`. Messages are the exact `Display` text the CLI prints.
+fn map_err(error: DecayError) -> PyErr {
+    match &error {
+        DecayError::Io { .. } => PyOSError::new_err(error.to_string()),
+        DecayError::ReadOnly { .. } => PyPermissionError::new_err(error.to_string()),
+        _ => PyValueError::new_err(error.to_string()),
+    }
+}
+
+/// Parses a kind argument into a `FileType`, rejecting anything else.
+fn file_type_from_str(kind: &str) -> PyResult<FileType> {
+    match kind {
+        "image" => Ok(FileType::Image),
+        "text" => Ok(FileType::Text),
+        other => Err(PyValueError::new_err(format!(
+            "kind must be \"image\" or \"text\", got {other:?}"
+        ))),
+    }
+}
+
+/// Corrupts a copy of `data` and returns the corrupted bytes.
+///
+/// Each eligible byte is independently replaced with probability
+/// `1 - exp(-x / 10)`; image payloads corrupt R, G, and B channels only and
+/// never touch alpha, text payloads are replaced with printable ASCII. `x` is
+/// not clamped: `x <= 0` corrupts nothing, and larger `x` approaches corrupting
+/// every byte. Because Python bytes are immutable, the input is copied once;
+/// use `corrupt_in_place` on a `bytearray` to avoid the copy.
+///
+/// The GIL is released while corruption runs, and large payloads are processed
+/// in parallel across cores.
+#[pyfunction]
+fn corrupt_bytes(
+    py: Python<'_>,
+    data: &Bound<'_, PyBytes>,
+    x: f64,
+    kind: &str,
+) -> PyResult<Py<PyBytes>> {
+    let file_type = file_type_from_str(kind)?;
+    let mut bytes = data.as_bytes().to_vec();
+    py.detach(|| decayfmt_core::corrupt::corrupt(&mut bytes, file_type, x));
+    Ok(PyBytes::new(py, &bytes).into())
+}
+
+/// Corrupts a `bytearray` in place, with no copy.
+///
+/// Same statistics as `corrupt_bytes`, but mutates the given buffer directly.
+/// Pass a `memoryview` by first converting it with `bytearray(mv)`. The GIL is
+/// released while corruption runs.
+#[pyfunction]
+fn corrupt_in_place(
+    py: Python<'_>,
+    buffer: &Bound<'_, PyByteArray>,
+    x: f64,
+    kind: &str,
+) -> PyResult<()> {
+    let file_type = file_type_from_str(kind)?;
+    // SAFETY: the slice is taken while the GIL is held and consumed entirely by
+    // the detach closure below; concurrent mutation of a bytearray from another
+    // Python thread is a race in plain Python too and is not protected here.
+    let bytes = unsafe { buffer.as_bytes_mut() };
+    py.detach(|| decayfmt_core::corrupt::corrupt(bytes, file_type, x));
+    Ok(())
+}
+
+/// Encodes a source file into a decayfmt file, exactly like the CLI `encode`.
+///
+/// The output name determines the payload type and x: `name.idcy<x>` for
+/// images, `name.tdcy<x>` for text. The produced file is clean; corruption
+/// only ever happens at open time.
+#[pyfunction]
+fn encode_file(py: Python<'_>, source_path: &str, output_path: &str) -> PyResult<()> {
+    let source = Path::new(source_path);
+    let output = Path::new(output_path);
+    py.detach(|| decayfmt_core::encode::encode_file(source, output))
+        .map_err(map_err)
+}
+
+/// Encodes in-memory bytes into a decayfmt file.
+///
+/// The bytes are treated as a source file: decoded to raw RGBA for image
+/// output names and validated as UTF-8 for text names. Useful for sources
+/// that are already in memory (e.g. an image from PIL), or when `encode_file`
+/// would require a temporary file.
+#[pyfunction]
+fn encode_bytes(py: Python<'_>, source: &Bound<'_, PyBytes>, output_path: &str) -> PyResult<()> {
+    let bytes = source.as_bytes().to_vec();
+    let output = Path::new(output_path);
+    py.detach(|| decayfmt_core::encode::encode_bytes(&bytes, output))
+        .map_err(map_err)
+}
+
+/// Opens a decayfmt file: permanently corrupts it on disk, no display.
+///
+/// This is the CLI's open minus the display step — the file on disk is
+/// corrupted and persisted, and the result is returned to Python. **There is
+/// no recovery: the previous payload state is gone.** Returns the file type
+/// label, the image dimensions (or `None` for text), and the full new file
+/// bytes including the untouched header.
+#[pyfunction]
+#[allow(clippy::type_complexity)]
+fn decay_file(py: Python<'_>, path: &str) -> PyResult<(String, Option<(u32, u32)>, Py<PyBytes>)> {
+    let path = Path::new(path);
+    let (header, file_bytes) = py
+        .detach(|| decayfmt_core::open::decay_in_place(path))
+        .map_err(map_err)?;
+    let kind = header.file_type.label().to_string();
+    let dimensions = header.dimensions.map(|d| (d.width, d.height));
+    let bytes = PyBytes::new(py, &file_bytes).into();
+    Ok((kind, dimensions, bytes))
+}
+
+/// Parses a decayfmt filename into its payload type label and instability x.
+///
+/// `photo.idcy3` parses as `("image", 3.0)` and `note.tdcy12` as
+/// `("text", 12.0)`. Raises `ValueError` for names that do not fit the
+/// convention.
+#[pyfunction]
+fn parse_filename(name: &str) -> PyResult<(String, f64)> {
+    let (file_type, x) = decayfmt_core::format::parse_filename(Path::new(name)).map_err(map_err)?;
+    Ok((file_type.label().to_string(), x))
+}
+
+/// Reads the 16-byte decayfmt header from `data` and returns its type label
+/// and image dimensions (`None` for text).
+#[pyfunction]
+fn read_header(data: &Bound<'_, PyBytes>) -> PyResult<(String, Option<(u32, u32)>)> {
+    let header = Header::read(data.as_bytes()).map_err(map_err)?;
+    Ok((
+        header.file_type.label().to_string(),
+        header.dimensions.map(|d| (d.width, d.height)),
+    ))
+}
+
+/// Builds a 16-byte decayfmt header.
+///
+/// `kind="image"` requires both `width` and `height`; `kind="text"` ignores
+/// them. Useful together with `encode_bytes`-style workflows that write their
+/// own files.
+#[pyfunction]
+fn write_header(
+    py: Python<'_>,
+    kind: &str,
+    width: Option<u32>,
+    height: Option<u32>,
+) -> PyResult<Py<PyBytes>> {
+    let file_type = file_type_from_str(kind)?;
+    let header = match file_type {
+        FileType::Image => match (width, height) {
+            (Some(width), Some(height)) => Header::for_image(width, height),
+            _ => {
+                return Err(PyValueError::new_err(
+                    "image headers require both width and height",
+                ));
+            }
+        },
+        FileType::Text => Header::for_text(),
+    };
+    Ok(PyBytes::new(py, &header.write()).into())
+}
+
+/// Python bindings for decayfmt.
+#[pymodule]
+fn decayfmt(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(corrupt_bytes, m)?)?;
+    m.add_function(wrap_pyfunction!(corrupt_in_place, m)?)?;
+    m.add_function(wrap_pyfunction!(encode_file, m)?)?;
+    m.add_function(wrap_pyfunction!(encode_bytes, m)?)?;
+    m.add_function(wrap_pyfunction!(decay_file, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_filename, m)?)?;
+    m.add_function(wrap_pyfunction!(read_header, m)?)?;
+    m.add_function(wrap_pyfunction!(write_header, m)?)?;
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    Ok(())
+}

--- a/python/tests/smoke.py
+++ b/python/tests/smoke.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Smoke tests for the decayfmt Python bindings.
+
+Plain asserts, no pytest: run with any Python >= 3.11 that has the wheel
+installed. Exercises every public function end to end, including the
+statistical properties of corruption through the Python boundary.
+"""
+
+import base64
+import os
+import tempfile
+import threading
+import time
+
+import decayfmt
+
+
+def changed_fraction(before, after):
+    assert len(before) == len(after)
+    return sum(a != b for a, b in zip(before, after)) / len(before)
+
+
+def main():
+    assert decayfmt.__version__ == "0.1.0", decayfmt.__version__
+    print("PASS import + __version__")
+
+    # --- corrupt_bytes: statistical behavior through Python ----------------
+    data = b"a" * 100_000
+    frac1 = changed_fraction(data, decayfmt.corrupt_bytes(data, 1.0, "text"))
+    frac10 = changed_fraction(data, decayfmt.corrupt_bytes(data, 10.0, "text"))
+    assert 0.085 < frac1 < 0.105, f"x=1 fraction {frac1} outside (0.085, 0.105)"
+    assert 0.61 < frac10 < 0.65, f"x=10 fraction {frac10} outside (0.61, 0.65)"
+    print(f"PASS corrupt_bytes statistics (x=1: {frac1:.4f}, x=10: {frac10:.4f})")
+
+    # --- corrupt_in_place: zero-copy mutation ------------------------------
+    buf = bytearray(b"a" * 100_000)
+    before = bytes(buf)
+    decayfmt.corrupt_in_place(buf, 10.0, "text")
+    assert bytes(buf) != before, "corrupt_in_place did not mutate the buffer"
+    assert len(buf) == 100_000
+    try:
+        decayfmt.corrupt_in_place(buf, 1.0, "garbage")
+        raise AssertionError("bad kind did not raise")
+    except ValueError as e:
+        assert "image" in str(e) and "text" in str(e)
+    print("PASS corrupt_in_place mutation + bad kind ValueError")
+
+    # --- image corruption preserves alpha -----------------------------------
+    pixels = b"\x00\x00\x00\xAB" * 10_000
+    img = bytearray(pixels)
+    decayfmt.corrupt_in_place(img, 10.0, "image")
+    for i in range(3, len(img), 4):
+        assert img[i] == 0xAB, f"alpha modified at index {i}"
+    assert img[0] != 0x00 or img[1] != 0x00 or img[2] != 0x00
+    print("PASS image alpha channel preserved")
+
+    # --- filename parsing ----------------------------------------------------
+    assert decayfmt.parse_filename("photo.idcy3") == ("image", 3.0)
+    assert decayfmt.parse_filename("note.tdcy12") == ("text", 12.0)
+    for bad in ["plain.txt", "photo.idcy", "photo.idcyx", "photo.idcy0"]:
+        try:
+            decayfmt.parse_filename(bad)
+            raise AssertionError(f"{bad!r} did not raise")
+        except ValueError:
+            pass
+    print("PASS parse_filename")
+
+    # --- header round trips ---------------------------------------------------
+    header = decayfmt.write_header("image", 2, 2)
+    assert len(header) == 16
+    assert header[:4] == b"DCYF"
+    assert decayfmt.read_header(header) == ("image", (2, 2))
+    text_header = decayfmt.write_header("text", None, None)
+    assert decayfmt.read_header(text_header) == ("text", None)
+    try:
+        decayfmt.write_header("image", None, None)
+        raise AssertionError("image header without dimensions did not raise")
+    except ValueError:
+        pass
+    print("PASS write_header/read_header round trips")
+
+    # --- encode + decay_file on a text file -----------------------------------
+    with tempfile.TemporaryDirectory() as tmp:
+        source = os.path.join(tmp, "source.txt")
+        output = os.path.join(tmp, "note.tdcy5")
+        with open(source, "w") as f:
+            f.write("the quick brown fox jumps over the lazy dog\n")
+
+        decayfmt.encode_file(source, output)
+        kind, dims, bytes1 = decayfmt.decay_file(output)
+        assert kind == "text" and dims is None
+        assert bytes1[:4] == b"DCYF"
+
+        _, _, bytes2 = decayfmt.decay_file(output)
+        assert bytes1 != bytes2, "two opens must produce different corruption"
+        assert len(bytes1) == len(bytes2), "open must preserve length"
+        assert bytes1[:16] == bytes2[:16], "header must never change"
+        assert bytes1[16:].count(b" ") > 0, "corrupted text should contain replacements"
+    print("PASS encode_file + decay_file (text, twice)")
+
+    # --- encode_bytes with an embedded 1x1 PNG --------------------------------
+    one_px_png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        output = os.path.join(tmp, "photo.idcy3")
+        decayfmt.encode_bytes(one_px_png, output)
+        kind, dims, bytes1 = decayfmt.decay_file(output)
+        assert kind == "image" and dims == (1, 1), (kind, dims)
+        assert bytes1[:4] == b"DCYF"
+    print("PASS encode_bytes + decay_file (1x1 PNG)")
+
+    # --- invalid UTF-8 refused at encode --------------------------------------
+    with tempfile.TemporaryDirectory() as tmp:
+        output = os.path.join(tmp, "note.tdcy3")
+        try:
+            decayfmt.encode_bytes(b"\xff\xfe not utf8", output)
+            raise AssertionError("invalid UTF-8 did not raise")
+        except ValueError as e:
+            assert "UTF-8" in str(e)
+    print("PASS invalid UTF-8 refused")
+
+    # --- soft GIL-release check -------------------------------------------------
+    done = threading.Event()
+    result = {}
+
+    def worker():
+        result["bytes"] = decayfmt.corrupt_bytes(
+            b"\x00" * (64 * 1024 * 1024), 10.0, "text"
+        )
+        done.set()
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    ticks = 0
+    while not done.is_set():
+        time.sleep(0.01)
+        ticks += 1
+    thread.join()
+    assert len(result["bytes"]) == 64 * 1024 * 1024
+    if ticks == 0:
+        print("WARN: main thread never ticked during 64 MiB corrupt (GIL not released?)")
+    else:
+        print(f"PASS GIL soft check (main thread ticked {ticks} times during 64 MiB corrupt)")
+
+    print("ALL SMOKE TESTS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/corrupt.rs
+++ b/src/corrupt.rs
@@ -4,9 +4,12 @@
 //! logic here; the caller is responsible for reading the payload, calling into
 //! this module, and writing the result back. The invariant this module upholds is
 //! that corruption is always stochastic and always drawn from a cryptographically
-//! secure generator seeded from operating system entropy, never from a fixed seed. It
-//! is never deterministic, because a reproducible corruption sequence could be replayed
-//! to reconstruct the original and undo the decay.
+//! secure generator seeded from operating system entropy, never from a fixed seed.
+//! It is never deterministic, because a reproducible corruption sequence could be
+//! replayed to reconstruct the original and undo the decay. Large payloads are
+//! processed in parallel regions, each of which seeds its own OS-entropy
+//! generator; the per-byte decisions stay independent across region boundaries,
+//! so the aggregate remains undirected noise.
 
 // `chunks_exact_to_as_chunks` (a newer clippy lint) suggests `slice::as_chunks`, which is
 // stable only from Rust 1.88; we keep `chunks_exact` to preserve a low minimum supported
@@ -15,7 +18,7 @@
 #![allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
 
 use crate::format::FileType;
-use rand::Rng;
+use rand::{Rng, RngCore};
 
 /// The divisor in the corruption probability curve p = 1 - exp(-x / DECAY_SCALE).
 ///
@@ -40,6 +43,26 @@ const PRINTABLE_ASCII_LOW: u8 = 0x20;
 /// Highest printable ASCII byte used as a text corruption replacement (tilde).
 const PRINTABLE_ASCII_HIGH: u8 = 0x7E;
 
+/// Number of printable ASCII bytes in the text replacement range.
+const PRINTABLE_ASCII_COUNT: u16 = (PRINTABLE_ASCII_HIGH - PRINTABLE_ASCII_LOW) as u16 + 1;
+
+/// Largest draw accepted for the cheap rejection-free text replacement mapping:
+/// 689 full copies of 0..95 fit in [0, 65455), so a draw below this value maps to
+/// a uniformly distributed replacement with no rejection. Draws at or above it
+/// (0.124% of the range) fall back to a direct uniform draw.
+const TEXT_REPLACEMENT_ACCEPT_MAX: u16 = PRINTABLE_ASCII_COUNT * 689;
+
+/// Bytes of payload processed per pool fill. Two u16 draws per byte covers the
+/// worst case (every byte corrupted), so one fill covers a chunk of this size.
+const CHUNK_BYTES: usize = 64 * 1024;
+
+/// Payload length below which the parallel path is not worth the coordination.
+const PAR_MIN_BYTES: usize = 1024 * 1024;
+
+/// Size of the contiguous region handed to each parallel task. Kept a multiple
+/// of 4 so image regions start on pixel boundaries and alpha stays at index 3.
+const REGION_BYTES: usize = 4 * 1024 * 1024;
+
 /// Derives the per-byte corruption probability from the instability value x.
 ///
 /// p = 1 - exp(-x / DECAY_SCALE). The exponential form makes p climb smoothly from
@@ -49,57 +72,146 @@ fn corruption_probability(x: f64) -> f64 {
     1.0 - (-x / DECAY_SCALE).exp()
 }
 
+/// Converts a probability to the 16-bit integer threshold used by the bulk
+/// corruption loops.
+///
+/// A byte is corrupted when its random draw, uniform over [0, 65536), is below
+/// the threshold, giving an effective per-byte probability of t / 65536. That
+/// deviates from the continuous p by at most 1 / 65536 (about 1.5e-5), which is
+/// far below what any filename x can distinguish. The cast saturates: p = 1
+/// becomes 65535, so even a saturated threshold leaves a 1-in-65536 byte
+/// untouched rather than promising exact certainty.
+fn probability_threshold(x: f64) -> u16 {
+    (corruption_probability(x) * 65536.0) as u16
+}
+
 /// Corrupts a payload in place according to its file type and instability value x.
 ///
-/// Mutates the slice directly. Randomness comes from `rand::thread_rng`, a
-/// cryptographically secure generator seeded from operating system entropy, drawn
-/// fresh per call, so two opens of the same bytes produce different results. Upholds
+/// Mutates the slice directly. Randomness is drawn in bulk from `rand::thread_rng`
+/// generators, cryptographically secure and seeded from operating system entropy;
+/// large payloads are split into parallel regions that each seed their own
+/// generator, so two opens of the same bytes produce different results. Upholds
 /// the invariant that corruption is never driven by a fixed, replayable seed.
 pub fn corrupt(payload: &mut [u8], file_type: FileType, x: f64) {
-    let probability = corruption_probability(x);
-    let mut rng = rand::thread_rng();
-    match file_type {
-        FileType::Image => corrupt_image(payload, probability, &mut rng),
-        FileType::Text => corrupt_text(payload, probability, &mut rng),
-    }
+    let threshold = probability_threshold(x);
+    corrupt_payload(payload, file_type, threshold);
 }
 
-/// Corrupts the R, G, and B channels of an RGBA payload, each independently, with
-/// the given probability. Upholds the invariant that the alpha channel is never
-/// touched: transparency is preserved so corruption shows as color noise rather
-/// than transparency holes. Any trailing bytes that do not form a whole pixel are
-/// left untouched, since a well-formed RGBA payload is a whole number of pixels.
-fn corrupt_image<R: Rng>(payload: &mut [u8], probability: f64, rng: &mut R) {
-    for pixel in payload.chunks_exact_mut(RGBA_BYTES_PER_PIXEL) {
-        for (index, channel) in pixel.iter_mut().enumerate() {
-            if index == ALPHA_INDEX {
-                continue;
-            }
-            if rng.gen::<f64>() < probability {
-                *channel = rng.gen::<u8>();
-            }
-        }
-    }
-}
-
-/// Corrupts a text payload by replacing bytes, each independently with the given
-/// probability, with a uniformly random printable ASCII byte (0x20 to 0x7E).
+/// Corrupts the eligible portion of `payload` using the given integer threshold.
 ///
-/// Operates on bytes, not Unicode codepoints, so at high x this can split or break
-/// multi-byte UTF-8 sequences. That is intended: the display layer is responsible
-/// for substituting the Unicode replacement character for whatever is no longer
-/// valid. This module only damages bytes.
-fn corrupt_text<R: Rng>(payload: &mut [u8], probability: f64, rng: &mut R) {
-    for byte in payload.iter_mut() {
-        if rng.gen::<f64>() < probability {
-            *byte = rng.gen_range(PRINTABLE_ASCII_LOW..=PRINTABLE_ASCII_HIGH);
+/// Text corrupts every byte; image corrupts only the R, G, and B channels of
+/// whole pixels, so the payload is truncated to a whole number of pixels and any
+/// trailing bytes are left untouched.
+fn corrupt_payload(payload: &mut [u8], file_type: FileType, threshold: u16) {
+    let eligible_len = match file_type {
+        FileType::Text => payload.len(),
+        FileType::Image => payload.len() - payload.len() % RGBA_BYTES_PER_PIXEL,
+    };
+    if eligible_len == 0 {
+        return;
+    }
+    let eligible = &mut payload[..eligible_len];
+
+    let parallel = eligible_len >= PAR_MIN_BYTES
+        && std::thread::available_parallelism()
+            .map(|cores| cores.get() > 1)
+            .unwrap_or(false);
+
+    if parallel {
+        use rayon::prelude::*;
+        // Disjoint contiguous regions, each a multiple of 4 so image pixels
+        // never straddle a boundary. Every region seeds its own OS-entropy
+        // generator, keeping per-byte decisions independent across boundaries.
+        eligible.par_chunks_mut(REGION_BYTES).for_each(|region| {
+            let mut rng = rand::thread_rng();
+            region_work(region, file_type, threshold, &mut rng);
+        });
+    } else {
+        let mut rng = rand::thread_rng();
+        region_work(eligible, file_type, threshold, &mut rng);
+    }
+}
+
+/// Corrupts a whole region sequentially, in sub-blocks of `CHUNK_BYTES`.
+///
+/// Per sub-block, one bulk fill of a u16 pool supplies all threshold and
+/// replacement draws for that block, so per-byte distribution calls are replaced
+/// by one stream fill plus integer compares. The pool is sized for the worst
+/// case of two draws per byte and is reused across sub-blocks, keeping transient
+/// memory bounded to the pool (256 KiB) per region.
+fn region_work<R: RngCore>(
+    mut region: &mut [u8],
+    file_type: FileType,
+    threshold: u16,
+    rng: &mut R,
+) {
+    let mut pool = vec![0u16; CHUNK_BYTES * 2];
+    while !region.is_empty() {
+        let chunk_len = region.len().min(CHUNK_BYTES);
+        let (chunk, rest) = region.split_at_mut(chunk_len);
+        region = rest;
+        rng.fill(&mut pool[..chunk_len * 2]);
+        match file_type {
+            FileType::Text => corrupt_text_chunk(chunk, threshold, &pool, rng),
+            FileType::Image => corrupt_image_chunk(chunk, threshold, &pool),
         }
+    }
+}
+
+/// Corrupts the R, G, and B channels of an RGBA payload chunk, each
+/// independently, with probability threshold / 65536. Upholds the invariant that
+/// the alpha channel is never touched: transparency is preserved so corruption
+/// shows as color noise rather than transparency holes. The low byte of a fresh
+/// u16 draw is the replacement, uniform over 0..=255.
+///
+/// Draws are consumed from `pool` strictly left to right, one per channel for
+/// the decision and one more only when the channel is corrupted; leftover pool
+/// entries are discarded, never reused.
+fn corrupt_image_chunk(chunk: &mut [u8], threshold: u16, pool: &[u16]) {
+    let mut draw = 0;
+    for pixel in chunk.chunks_exact_mut(RGBA_BYTES_PER_PIXEL) {
+        for channel in pixel.iter_mut().take(ALPHA_INDEX) {
+            if pool[draw] < threshold {
+                draw += 1;
+                *channel = pool[draw] as u8;
+            }
+            draw += 1;
+        }
+    }
+}
+
+/// Corrupts a text payload chunk by replacing bytes, each independently with
+/// probability threshold / 65536, with a uniformly random printable ASCII byte
+/// (0x20 to 0x7E).
+///
+/// Operates on bytes, not Unicode codepoints, so at high x this can split or
+/// break multi-byte UTF-8 sequences. That is intended: the display layer is
+/// responsible for substituting the Unicode replacement character for whatever
+/// is no longer valid. This module only damages bytes.
+fn corrupt_text_chunk<R: RngCore>(chunk: &mut [u8], threshold: u16, pool: &[u16], rng: &mut R) {
+    let mut draw = 0;
+    for byte in chunk.iter_mut() {
+        if pool[draw] < threshold {
+            draw += 1;
+            let r = pool[draw];
+            // 689 full copies of 0..94 fit in [0, 65455), so this maps a draw
+            // to an exactly uniform replacement without rejection. The rare
+            // high draw falls back to a direct uniform draw from the stream.
+            *byte = if r < TEXT_REPLACEMENT_ACCEPT_MAX {
+                PRINTABLE_ASCII_LOW + (r % PRINTABLE_ASCII_COUNT) as u8
+            } else {
+                rng.gen_range(PRINTABLE_ASCII_LOW..=PRINTABLE_ASCII_HIGH)
+            };
+        }
+        draw += 1;
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
 
     /// Tolerance for comparing an observed corruption fraction against its expected
     /// probability, as specified by the milestone.
@@ -119,6 +231,17 @@ mod tests {
         // x = 1 gives roughly 0.095; x = 10 gives roughly 0.632.
         assert!((corruption_probability(1.0) - 0.095).abs() < 0.001);
         assert!((corruption_probability(10.0) - 0.632).abs() < 0.001);
+    }
+
+    #[test]
+    fn threshold_quantization_stays_within_one_65536th() {
+        // The integer threshold deviates from the continuous probability by at
+        // most 1 / 65536 for every x the format can express.
+        for x in [0.5, 1.0, 2.0, 5.0, 10.0, 25.0] {
+            let p = corruption_probability(x);
+            let t = probability_threshold(x);
+            assert!((t as f64 / 65536.0 - p).abs() <= 1.0 / 65536.0 + 1e-12);
+        }
     }
 
     #[test]
@@ -235,6 +358,152 @@ mod tests {
             "x=10 image RGB fraction {} not within {} of 0.632",
             fraction,
             FRACTION_TOLERANCE
+        );
+    }
+
+    /// All payloads below the parallel threshold exercise the serial path; the
+    /// following large-payload tests push corruption onto the rayon path and
+    /// across region boundaries.
+
+    #[test]
+    fn image_alpha_never_modified_large_parallel() {
+        // An 8 MiB RGBA payload with an alpha sentinel forces the parallel path
+        // (>= PAR_MIN_BYTES) and spans multiple 4 MiB regions, so alpha survival
+        // is checked across region boundaries.
+        const PAYLOAD_BYTES: usize = 8 * 1024 * 1024;
+        const ALPHA_SENTINEL: u8 = 0xCD;
+        let mut payload = Vec::with_capacity(PAYLOAD_BYTES);
+        while payload.len() < PAYLOAD_BYTES {
+            payload.extend_from_slice(&[0x00, 0x00, 0x00, ALPHA_SENTINEL]);
+        }
+
+        corrupt(&mut payload, FileType::Image, 10.0);
+
+        assert_eq!(
+            payload.len(),
+            PAYLOAD_BYTES,
+            "corruption changed the length"
+        );
+        for pixel in payload.chunks_exact(RGBA_BYTES_PER_PIXEL) {
+            assert_eq!(
+                pixel[ALPHA_INDEX], ALPHA_SENTINEL,
+                "alpha channel was modified by parallel corruption"
+            );
+        }
+    }
+
+    #[test]
+    fn large_text_fraction_near_expected() {
+        // 8 MiB all-zero payload spans multiple parallel regions; the measured
+        // fraction must still match the continuous probability within tolerance.
+        for (x, expected) in [(1.0, 0.095), (10.0, 0.632)] {
+            let original = vec![0u8; 8 * 1024 * 1024];
+            let mut payload = original.clone();
+            corrupt(&mut payload, FileType::Text, x);
+            let fraction = changed_count(&original, &payload) as f64 / original.len() as f64;
+            assert!(
+                (fraction - expected).abs() < FRACTION_TOLERANCE,
+                "x={} text fraction {} not within {} of {}",
+                x,
+                fraction,
+                FRACTION_TOLERANCE,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn large_image_rgb_fraction_near_expected() {
+        // 8 MiB RGBA payload forces the parallel path; only R, G, B channels
+        // count, and the 1-in-256 chance a replacement lands on zero keeps the
+        // observed fraction within tolerance.
+        let payload = vec![0u8; 8 * 1024 * 1024];
+        for (x, expected) in [(1.0, 0.095), (10.0, 0.632)] {
+            let mut corrupted = payload.clone();
+            corrupt(&mut corrupted, FileType::Image, x);
+
+            let mut changed = 0usize;
+            for pixel in corrupted.chunks_exact(RGBA_BYTES_PER_PIXEL) {
+                for channel in pixel.iter().take(ALPHA_INDEX) {
+                    if *channel != 0 {
+                        changed += 1;
+                    }
+                }
+            }
+            let rgb_channels = corrupted.len() / RGBA_BYTES_PER_PIXEL * 3;
+            let fraction = changed as f64 / rgb_channels as f64;
+            assert!(
+                (fraction - expected).abs() < FRACTION_TOLERANCE,
+                "x={} image RGB fraction {} not within {} of {}",
+                x,
+                fraction,
+                FRACTION_TOLERANCE,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn image_trailing_bytes_untouched() {
+        // A payload that is not a whole number of pixels leaves its trailing
+        // bytes alone, exactly as a well-formed RGBA payload's remainder should.
+        const PIXELS: usize = 1_000;
+        const TRAILING: [u8; 2] = [0xDE, 0xAD];
+        let mut payload = vec![0u8; PIXELS * RGBA_BYTES_PER_PIXEL];
+        payload.extend_from_slice(&TRAILING);
+
+        corrupt(&mut payload, FileType::Image, 10.0);
+
+        assert_eq!(
+            &payload[payload.len() - TRAILING.len()..],
+            &TRAILING,
+            "trailing bytes were modified by image corruption"
+        );
+    }
+
+    #[test]
+    fn region_worker_reproduces_with_seeded_rng() {
+        // The pool-indexing logic is deterministic for a fixed stream: the same
+        // seed through the region worker must reproduce byte-identical output.
+        // This guards the draw accounting; the statistical tests guard the
+        // distribution.
+        let threshold = probability_threshold(10.0);
+        let original: Vec<u8> = (0..200_000u32).map(|i| (i % 251) as u8).collect();
+
+        let mut a = original.clone();
+        region_work(
+            &mut a,
+            FileType::Text,
+            threshold,
+            &mut StdRng::seed_from_u64(42),
+        );
+        let mut b = original.clone();
+        region_work(
+            &mut b,
+            FileType::Text,
+            threshold,
+            &mut StdRng::seed_from_u64(42),
+        );
+        assert_eq!(a, b, "same seed must reproduce identical corruption");
+
+        let image_payload = vec![0u8; 4_000 * RGBA_BYTES_PER_PIXEL];
+        let mut image_a = image_payload.clone();
+        region_work(
+            &mut image_a,
+            FileType::Image,
+            threshold,
+            &mut StdRng::seed_from_u64(42),
+        );
+        let mut image_b = image_payload.clone();
+        region_work(
+            &mut image_b,
+            FileType::Image,
+            threshold,
+            &mut StdRng::seed_from_u64(42),
+        );
+        assert_eq!(
+            image_a, image_b,
+            "same seed must reproduce identical corruption"
         );
     }
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -9,6 +9,7 @@
 use crate::error::DecayError;
 use crate::format::{FileType, Header};
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 
 /// Decodes a source image's bytes into its pixel dimensions and a raw RGBA payload.
@@ -17,7 +18,7 @@ use std::path::Path;
 /// reduced here to raw RGBA, four bytes per pixel, which is exactly what the
 /// decayfmt payload stores. The dimensions are returned alongside so the header can
 /// record them; the payload is the pixel data only and does not encode its own size.
-fn decode_image(source_bytes: &[u8], input: &Path) -> Result<(u32, u32, Vec<u8>), DecayError> {
+pub fn decode_image(source_bytes: &[u8], input: &Path) -> Result<(u32, u32, Vec<u8>), DecayError> {
     let decoded =
         image::load_from_memory(source_bytes).map_err(|error| DecayError::ImageDecode {
             context: format!("encode: decode image '{}': {}", input.display(), error),
@@ -32,7 +33,7 @@ fn decode_image(source_bytes: &[u8], input: &Path) -> Result<(u32, u32, Vec<u8>)
 /// The payload is stored as raw UTF-8 bytes exactly as read. Invalid UTF-8 is
 /// refused at encode time so that only well-formed text ever enters the format;
 /// the later corruption at open time is what may break that validity.
-fn text_payload(source_bytes: Vec<u8>) -> Result<Vec<u8>, DecayError> {
+pub fn text_payload(source_bytes: Vec<u8>) -> Result<Vec<u8>, DecayError> {
     match std::str::from_utf8(&source_bytes) {
         Ok(_) => Ok(source_bytes),
         Err(_) => Err(DecayError::InvalidUtf8),
@@ -42,16 +43,17 @@ fn text_payload(source_bytes: Vec<u8>) -> Result<Vec<u8>, DecayError> {
 /// Writes the header and raw payload to the output path as a single file.
 ///
 /// The header is written exactly once, here, and is never rewritten afterward.
-/// The payload follows immediately after the fixed 16-byte header.
-fn write_decayfmt(output: &Path, header: Header, payload: &[u8]) -> Result<(), DecayError> {
-    let header_bytes = header.write();
-    let mut file_bytes = Vec::with_capacity(header_bytes.len() + payload.len());
-    file_bytes.extend_from_slice(&header_bytes);
-    file_bytes.extend_from_slice(payload);
-    fs::write(output, &file_bytes).map_err(|error| DecayError::Io {
+/// The payload follows immediately after the fixed 16-byte header. The two are
+/// written with two calls so the payload is never copied into a second full-size
+/// buffer; the bytes on disk are identical to writing one concatenated buffer.
+pub fn write_decayfmt(output: &Path, header: Header, payload: &[u8]) -> Result<(), DecayError> {
+    let write_error = |error| DecayError::Io {
         context: format!("encode: write output '{}'", output.display()),
         source: error,
-    })
+    };
+    let mut file = fs::File::create(output).map_err(write_error)?;
+    file.write_all(&header.write()).map_err(write_error)?;
+    file.write_all(payload).map_err(write_error)
 }
 
 /// Encodes a source file at `input` into a decayfmt file at `output`.
@@ -64,6 +66,9 @@ fn write_decayfmt(output: &Path, header: Header, payload: &[u8]) -> Result<(), D
 /// are written out. No corruption is applied; the produced file is clean and parses
 /// cleanly via format.rs. The value of x is not stored; it lives only in the filename.
 pub fn encode_file(input: &Path, output: &Path) -> Result<(), DecayError> {
+    // Parse the output name first, before any read: an output name that could
+    // never be opened is refused rather than producing a permanently unopenable
+    // file.
     let (file_type, _x) = crate::format::parse_filename(output)?;
 
     let source_bytes = fs::read(input).map_err(|error| DecayError::Io {
@@ -71,9 +76,32 @@ pub fn encode_file(input: &Path, output: &Path) -> Result<(), DecayError> {
         source: error,
     })?;
 
+    build_and_write(file_type, source_bytes, input, output)
+}
+
+/// Encodes in-memory source bytes into a decayfmt file at `output`.
+///
+/// The bytes are treated as a source file: decoded to raw RGBA for images and
+/// validated as UTF-8 for text, exactly as `encode_file` treats a file on disk.
+/// The payload type and x come from the output filename, as always.
+pub fn encode_bytes(source: &[u8], output: &Path) -> Result<(), DecayError> {
+    let (file_type, _x) = crate::format::parse_filename(output)?;
+    build_and_write(file_type, source.to_vec(), output, output)
+}
+
+/// Turns already-read source bytes into a header and payload and writes them out.
+///
+/// `source_path` names the source only for error message context; the bytes have
+/// already been read by the caller.
+fn build_and_write(
+    file_type: FileType,
+    source_bytes: Vec<u8>,
+    source_path: &Path,
+    output: &Path,
+) -> Result<(), DecayError> {
     let (header, payload) = match file_type {
         FileType::Image => {
-            let (width, height, payload) = decode_image(&source_bytes, input)?;
+            let (width, height, payload) = decode_image(&source_bytes, source_path)?;
             (Header::for_image(width, height), payload)
         }
         FileType::Text => (Header::for_text(), text_payload(source_bytes)?),

--- a/src/open.rs
+++ b/src/open.rs
@@ -44,7 +44,10 @@ fn ensure_writable(path: &Path) -> Result<(), DecayError> {
 /// contract: parse x, verify writability, corrupt the payload, write it back. It
 /// performs no display, so the corruption it commits never depends on anything
 /// being shown. The header is read but never changed; only the payload is corrupted.
-fn decay_in_place(path: &Path) -> Result<(Header, Vec<u8>), DecayError> {
+///
+/// Public so embedding callers (such as the Python bindings) can commit an open
+/// without the display side of `open_file`.
+pub fn decay_in_place(path: &Path) -> Result<(Header, Vec<u8>), DecayError> {
     let (filename_type, x) = parse_filename(path)?;
     ensure_writable(path)?;
 


### PR DESCRIPTION
### Added
- **Python bindings via PyO3** — new `python/` crate publishing the `decayfmt-py` package on PyPI (import name: `decayfmt`).
  - `corrupt_bytes(data, x, kind)` — decayed copy of immutable bytes
  - `corrupt_in_place(buffer, x, kind)` — zero-copy decay of a `bytearray`
  - `encode_file(source, output)` / `encode_bytes(source, output)` — encode clean files
  - `decay_file(path)` — open without display: permanently corrupts on disk, returns `(kind, dims, bytes)`
  - `parse_filename(name)`, `read_header(data)`, `write_header(kind, width, height)`, `__version__`
  - Errors map to built-ins: `OSError` (I/O), `PermissionError` (read-only target), `ValueError` (everything else) — messages match the CLI exactly
  - abi3 wheels for Python 3.11+; requires-python `>=3.11`
- **GitHub Actions workflow** (`python.yml`) — builds and smoke-tests wheels on 5 platforms (manylinux x86_64 + aarch64, macOS arm64 + x86_64, Windows), publishes to PyPI via trusted publishing on `py-v*` tags
- **Docs** — `python/README.md` (PyPI long description), `python/examples/example.py` (every function + every exception), `python/RELEASE.md` (release checklist), new `## Python` and `## Performance` sections in root README

### Changed
- **Corruption loop rewritten for throughput** — bulk u16 RNG pools replace per-byte f64 draws, exact-replacement tables replace rejection sampling, payloads ≥ 1 MiB corrupt in parallel (rayon) across cores. Measured on this machine (macOS arm64, 64 MiB payload): text x=1 **142 → 1366 MiB/s (9.6x)**, text x=10 **85.6 → 754 MiB/s (8.8x)**, image x=1 **187 → 1421 MiB/s (7.6x)**, image x=10 **116 → 950 MiB/s (8.2x)**
  - Statistics unchanged: per-byte probability stays `1 - exp(-x/10)` (quantization ≤ 1/65536), image alpha never touched, trailing non-pixel bytes untouched, randomness stays OS-entropy-seeded and never replayable
- **Encode path** — dropped second full-size buffer in `write_decayfmt` (header + payload streamed); text encode measured **7.9 → 3.9 ms (2.0x)**
- **Smaller dependency tree** — `image` default features trimmed (avif encode-only dead code, internal rayon); rav1e removed from lockfile. Decode format parity kept (exr retained)
- **Cargo workspace** — `members = ["python"]` with `default-members = ["."]`; existing CLI CI/release workflows untouched


Benchmark | Before | After | Improvement
-- | -- | -- | --
Text corruption ×1 | 142 MiB/s | 1,366 MiB/s | 9.6× faster
Text corruption ×10 | 86 MiB/s | 754 MiB/s | 8.8× faster
Image corruption ×1 | 187 MiB/s | 1,421 MiB/s | 7.6× faster
Image corruption ×10 | 116 MiB/s | 950 MiB/s | 8.2× faster
Encode 16 MiB text | 7.9 ms | 3.9 ms | 2× faster


### Internal (no CLI behavior change)
- `encode::encode_bytes`, `decode_image`, `text_payload`, `write_decayfmt`, `open::decay_in_place` now `pub` for embedding
- New bench harness (`benches/`, no new dependencies, `DECAY_BENCH_MB` override) and large-payload statistical tests (8 MiB parallel path, seeded determinism, alpha/tail invariance)

### Notes
- CLI functionality, commands, error messages, and file format are unchanged — perf work and Python binding sit on top of the existing library
- End-to-end encode is bounded by image decode + disk I/O; the large speedups above are the corruption step
- PyPI package name is `decayfmt-py` (import stays `decayfmt`); releases tagged `py-v*` independently of CLI `v*` tags